### PR TITLE
fix REGISTRY_HOST: remove suffix .cluster.local

### DIFF
--- a/manifests-all.yaml
+++ b/manifests-all.yaml
@@ -75,7 +75,7 @@ spec:
             memory: 50Mi
         env:
         - name: REGISTRY_HOST
-          value: registry.registry.svc.cluster.local
+          value: registry.registry.svc
         - name: REGISTRY_PORT
           value: "5000"
         - name: FORWARD_PORT

--- a/manifests/proxy/daemonset.yaml
+++ b/manifests/proxy/daemonset.yaml
@@ -22,7 +22,7 @@ spec:
             memory: 50Mi
         env:
         - name: REGISTRY_HOST
-          value: registry.registry.svc.cluster.local
+          value: registry.registry.svc
         - name: REGISTRY_PORT
           value: "5000"
         - name: FORWARD_PORT


### PR DESCRIPTION
I found these entries in the logs of the proxy containers, that it was trying to connect registry.registry.svc.cluster.local ... and was waiting for "a long time".

This hostname is wrong which could be checked by running e.g.
`kubectl exec -p enter-your-registry-proxy-7awzz-pod -i -t -n registry -- sh`
and then run
` nslookup registry.registry.svc.cluster.local` -> fails
` nslookup registry.registry.svc` -> worx

I already checked the fix: after applying this change, no more 'waiting for connection' messages are logged.